### PR TITLE
Clean up for Creator and Business models

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -4,8 +4,6 @@ const db = require('./data');
 
 const app = express();
 
-const { User } = db.models;
-
 app.use('/assets', express.static(path.join(__dirname, '../frontend/assets')));
 
 app.use(express.json());

--- a/backend/data/index.js
+++ b/backend/data/index.js
@@ -3,12 +3,12 @@ const connection = require('./connection');
 const sync = require('./sync');
 
 // Models
-const { User, Business } = require('./models');
+const { Creator, Business } = require('./models');
 
 module.exports = {
   connection,
   models: {
-    User,
+    Creator,
     Business
   },
   sync

--- a/backend/data/models/Business.js
+++ b/backend/data/models/Business.js
@@ -41,14 +41,10 @@ const Business = connection.define('business', {
   }
 });
 
-Business.authenticate = function(businessUser) {
-  return connection.transaction(function(transaction) {
-    return Business.findOrCreate({
-      where: {
-        ...businessUser
-      },
-      transaction
-    });
+Business.authenticate = function(user) {
+  return Business.findOrCreate({
+    where: { linkedInId: user.linkedInId },
+    defaults: user
   });
 };
 

--- a/backend/data/models/Creator.js
+++ b/backend/data/models/Creator.js
@@ -1,8 +1,6 @@
 const connection = require('../connection');
 const { Sequelize } = connection;
-const {
-  STRING, UUID, UUIDV4, VIRTUAL
-} = Sequelize;
+const { STRING, UUID, UUIDV4, VIRTUAL } = Sequelize;
 
 const Creator = connection.define(
   'creator',
@@ -55,5 +53,12 @@ const Creator = connection.define(
     }
   }
 );
+
+Creator.authenticate = function (user) {
+  return Creator.findOrCreate({
+    where: { facebookId: user.facebookId },
+    defaults: user
+  });
+};
 
 module.exports = Creator;

--- a/backend/data/models/Creator.js
+++ b/backend/data/models/Creator.js
@@ -1,11 +1,11 @@
 const connection = require('../connection');
 const { Sequelize } = connection;
 const {
-  STRING, UUID, UUIDV4, VIRTUAL, BOOLEAN
+  STRING, UUID, UUIDV4, VIRTUAL
 } = Sequelize;
 
-const User = connection.define(
-  'user',
+const Creator = connection.define(
+  'creator',
   {
     id: {
       type: UUID,
@@ -56,4 +56,4 @@ const User = connection.define(
   }
 );
 
-module.exports = User;
+module.exports = Creator;

--- a/backend/data/models/index.js
+++ b/backend/data/models/index.js
@@ -1,7 +1,7 @@
-const User = require('./User');
+const Creator = require('./Creator');
 const Business = require('./Business');
 
 module.exports = {
-  User,
+  Creator,
   Business
 };

--- a/backend/routes/auth/facebook.js
+++ b/backend/routes/auth/facebook.js
@@ -1,10 +1,7 @@
 const router = require("express").Router();
 const { Creator } = require("../../data/models");
 
-/* facebook authorization */
-
-// save facebook user info to database
-router.post("/add", (req, res, next) => {
+router.post("/", (req, res, next) => {
   const user = req.body;
   if (user) {
     Creator.findOrCreate({ where: { email: user.email }, defaults: user })

--- a/backend/routes/auth/facebook.js
+++ b/backend/routes/auth/facebook.js
@@ -4,7 +4,7 @@ const { Creator } = require("../../data/models");
 router.post("/", (req, res, next) => {
   const user = req.body;
   if (user) {
-    Creator.findOrCreate({ where: { email: user.email }, defaults: user })
+    Creator.findOrCreate({ where: { facebookId: user.facebookId }, defaults: user })
       .then(newUser => {
         res.send(newUser.data);
       })

--- a/backend/routes/auth/facebook.js
+++ b/backend/routes/auth/facebook.js
@@ -4,9 +4,9 @@ const { Creator } = require("../../data/models");
 router.post("/", (req, res, next) => {
   const user = req.body;
   if (user) {
-    Creator.findOrCreate({ where: { facebookId: user.facebookId }, defaults: user })
-      .then(newUser => {
-        res.send(newUser.data);
+    Creator.authenticate(user)
+      .then(creator => {
+        res.send(creator);
       })
       .catch(ex => console.log(ex));
   }

--- a/backend/routes/auth/facebook.js
+++ b/backend/routes/auth/facebook.js
@@ -1,5 +1,5 @@
 const router = require("express").Router();
-const { User } = require("../../data/models");
+const { Creator } = require("../../data/models");
 
 /* facebook authorization */
 
@@ -7,7 +7,7 @@ const { User } = require("../../data/models");
 router.post("/add", (req, res, next) => {
   const user = req.body;
   if (user) {
-    User.findOrCreate({ where: { email: user.email }, defaults: user })
+    Creator.findOrCreate({ where: { email: user.email }, defaults: user })
       .then(newUser => {
         res.send(newUser.data);
       })

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,22 +1,25 @@
 require("dotenv").config();
+const fs = require("fs");
+const https = require("https");
 
 const db = require("./data");
 const app = require("./app");
 const port = process.env.PORT || 3000;
-const fs = require("fs");
-const https = require("https");
+
+const startUpCallback = () => console.log(`listening on port ${port}`);
 
 db.sync(true).then(() => {
-  // enable https in Express
-  https
-    .createServer(
-      {
-        key: fs.readFileSync("server.key"),
-        cert: fs.readFileSync("server.cert")
-      },
-      app
-    )
-    .listen(port, function() {
-      console.log(`listening on port ${port}`);
-    });
+  if (process.env.NODE_ENV === 'production') {
+    app.listen(port, startUpCallback);
+  } else {
+    https
+      .createServer(
+        {
+          key: fs.readFileSync("server.key"),
+          cert: fs.readFileSync("server.cert")
+        },
+        app
+      )
+      .listen(port, startUpCallback);
+  }
 });

--- a/frontend/src/components/App.jsx
+++ b/frontend/src/components/App.jsx
@@ -13,14 +13,6 @@ import Login from "./Login";
 import Logout from "./Logout";
 
 class App extends Component {
-  componentDidMount() {
-    const {
-      attemptSessionLogin,
-    } = this.props;
-
-    // getLoginStatus();
-  }
-
   render() {
     return (
       <HashRouter>
@@ -35,8 +27,4 @@ class App extends Component {
   }
 }
 
-const mapDispatchToProps = (dispatch) => ({
-  // getLoginStatus: () => dispatch(actions.getLoginStatus())
-});
-
-export default connect(null, mapDispatchToProps)(App);
+export default connect(null)(App);

--- a/frontend/src/components/Home.jsx
+++ b/frontend/src/components/Home.jsx
@@ -8,12 +8,9 @@ import { actions } from "../store";
 class Home extends Component {
   render() {
     return (
-      <div>Home page
-        </div>
+      <div>Home page</div>
     );
   }
 }
 
-const mapStateToProps = ({}) => ({});
-
-export default connect(mapStateToProps)(Home);
+export default connect(null)(Home);

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -1,10 +1,10 @@
 // Package imports
 import React, { Component } from "react";
 import { connect } from "react-redux";
+import FacebookLogin from "react-facebook-login";
 
 // Local imports
 import { actions } from "../store";
-import FacebookLogin from "react-facebook-login";
 
 class Login extends Component {
   constructor() {
@@ -43,14 +43,12 @@ class Login extends Component {
           <h2>For Creators:</h2>
           <FacebookLogin
             appId="507675923424391"
-            fields="first_name, last_name,email,picture"
-            // autoLoad={true}
+            fields="first_name,last_name,email,picture"
             callback={facebookLogin}
             icon="fa-facebook"
             size="medium"
-            scope="public_profile, user_photos, user_posts, instagram_basic, instagram_manage_insights"
+            scope="public_profile,email"
             textButton="Sign In With Facebook"
-            redirectUri="/"
           />
         </div>
       </div>
@@ -65,111 +63,3 @@ const mapDispatchToProps = (dispatch, { history }) => ({
 });
 
 export default connect(null, mapDispatchToProps)(Login);
-
-// * This was replaced by react-facebook-login package
-// using facebook sdk but FB displayed as undefined
-// will use it later if the issues are resolved
-// *
-
-// window.fbAsyncInit = function() {
-//   FB.init({
-//     appId: "507675923424391",
-//     cookie: true,
-//     xfbml: true,
-//     version: "v5.0"
-//   });
-
-//   const fb_init = new Event("FacebookObject");
-//   document.dispatchEvent(fb_init);
-// };
-
-// (function(d, s, id) {
-//   var js,
-//     fjs = d.getElementsByTagName(s)[0];
-//   if (d.getElementById(id)) {
-//     return;
-//   }
-//   js = d.createElement(s);
-//   js.id = id;
-//   js.src = "https://connect.facebook.net/en_US/sdk.js";
-//   fjs.parentNode.insertBefore(js, fjs);
-// })(document, "script", "facebook-jssdk");
-
-// class FacebookLogin extends Component {
-//   componentDidMount() {
-//     document.addEventListener("FacebookObject", this.initializeFacebookLogin);
-//   }
-
-//   componentWillUnmount() {
-//     document.removeEventListener("FacebookObject", this.initializeFacebookLogin);
-//   }
-
-//   // Initialize facebook object & check login status
-//   initializeFacebookLogin(){
-//     this.FB = window.FB;
-//     this.checkLoginStatus();
-//   };
-
-//   checkLoginStatus(){
-//     this.FB.getLoginStatus(this.facebookLoginHandler);
-//   };
-
-//   facebookLogin(){
-//     // if (!this.FB) return;
-
-//     this.FB.getLoginStatus(response => {
-//       if (response.status === "connected") {
-//         this.facebookLoginHandler(response);
-//       } else {
-//         this.FB.login(this.facebookLoginHandler, { scope: "public_profile" });
-//       }
-//     });
-//   };
-
-//   facebookLoginHandler(response){
-//       this.FB.api("/me", userData => {
-//         let result = {
-//           ...response,
-//           user: userData
-//         };
-//         this.props.onLogin(true, result);
-//       });
-//   };
-
-//   render() {
-//     return <div onClick={this.facebookLogin}>{this.props}</div>;
-//   }
-// }
-
-// class SignUp extends Component {
-
-// render() {
-//     return (
-//       <div>
-//         <div id="businessLogin">
-//           <h2>For Business:</h2>
-//           <a href="/auth/linkedin">
-//             <img src="./assets/images/linkedin-signin.png" />
-//           </a>
-//         </div>
-//         <div id="creatorLogin">
-//           <h2>For Creators:</h2>
-//           <FacebookLogin onLogin={this.onFacebookLogin}>
-//                 <button>Facebook</button>
-//               </FacebookLogin>
-//           {/* <div
-//             className="fb-login-button"
-//             data-width=""
-//             data-size="large"
-//             data-scope="public_profile,email"
-//             data-button-type="login_with"
-//             //   data-auto-logout-link="/user/logout" //need to create a path
-//             data-use-continue-as="false"
-//             onClick={this.facebookLogin}
-//           >
-//           </div> */}
-//         </div>
-//       </div>
-//     );
-//   }
-// }

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -42,7 +42,7 @@ class Login extends Component {
         <div id="creatorLogin">
           <h2>For Creators:</h2>
           <FacebookLogin
-            appId="507675923424391"
+            appId={process.env.FB_APP_ID}
             fields="first_name,last_name,email,picture"
             callback={facebookLogin}
             icon="fa-facebook"

--- a/frontend/src/components/Logout.jsx
+++ b/frontend/src/components/Logout.jsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { actions } from '../store';
 
-/* Logout */
 class Logout extends Component {
   constructor() {
     super();

--- a/frontend/src/components/Nav.jsx
+++ b/frontend/src/components/Nav.jsx
@@ -8,7 +8,7 @@ import { actions } from "../store";
 
 class Nav extends Component {
   render() {
-    const {loggedIn} = this.props
+    const { loggedIn } = this.props
     return (
       <div>
         <NavLink to="/" exact>
@@ -28,8 +28,8 @@ class Nav extends Component {
   }
 }
 
-const mapStateToProps = ({ auth }) => {
-  return { loggedIn: !!auth.token, auth };
-};
+const mapStateToProps = ({ auth }) => ({
+  loggedIn: !!auth.token
+});
 
 export default connect(mapStateToProps)(Nav);

--- a/frontend/src/store/actions.js
+++ b/frontend/src/store/actions.js
@@ -2,7 +2,7 @@ import axios from "axios";
 import { SET_AUTH, DELETE_AUTH } from "./constants";
 
 const attemptToLogin = (auth, history) => async dispatch => {
-  const user = (await axios.post("/auth/facebook/add", auth.user)).data;
+  (await axios.post("/auth/facebook/", auth.user)).data;
   dispatch({
     type: SET_AUTH,
     auth

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,8 +22,8 @@ module.exports = {
   },
   plugins: [
     new Dotenv({
-      path: './.env', // Path to .env file (this is the default) 
-      safe: true // load .env.example (defaults to "false" which does not use dotenv-safe) 
+      path: './.env',
+      systemvars: true
     })
   ]
 };


### PR DESCRIPTION
This PR has the following updates:
- add email for FB scope (also removed unnecessary permissions, **for now**)
- rename User model to Creator
- fix env var problems when deploying to Heroku
- do not use https createServer if in production
- use Facebook ID as the basis of Creator record creation, not email