### PR TITLE
Add keywords that a Creator can choose from

### DIFF
--- a/backend/data/index.js
+++ b/backend/data/index.js
@@ -1,15 +1,7 @@
-// DB Stuff
-const connection = require('./connection');
 const sync = require('./sync');
-
-// Models
-const { Creator, Business } = require('./models');
+const models = require('./models');
 
 module.exports = {
-  connection,
-  models: {
-    Creator,
-    Business
-  },
+  models,
   sync
 };

--- a/backend/data/models/Keyword.js
+++ b/backend/data/models/Keyword.js
@@ -1,0 +1,13 @@
+const connection = require('../connection');
+const { Sequelize } = connection;
+const { STRING } = Sequelize;
+
+const Keyword = connection.define('keyword', {
+  name: {
+    type: STRING,
+    allowNull: false,
+    unique: true
+  }
+});
+
+module.exports = Keyword;

--- a/backend/data/models/index.js
+++ b/backend/data/models/index.js
@@ -1,11 +1,14 @@
-const Creator = require("./Creator");
-const Business = require("./Business");
-const CreatorInsight = require("./CreatorInsight");
+const Creator = require('./Creator');
+const Business = require('./Business');
+const CreatorInsight = require('./CreatorInsight');
+const Keyword = require('./Keyword');
+
 Creator.hasMany(CreatorInsight);
 CreatorInsight.belongsTo(Creator);
 
 module.exports = {
   Creator,
   Business,
-  CreatorInsight
+  CreatorInsight,
+  Keyword
 };

--- a/backend/data/seed.js
+++ b/backend/data/seed.js
@@ -1,0 +1,46 @@
+const { Keyword } = require('./models');
+
+const keywordList = [
+  'Adventure',
+  'Art',
+  'Baby',
+  'Beauty',
+  'Business',
+  'Craft',
+  'Decorating',
+  'Design',
+  'DIY',
+  'Education',
+  'Entertainment',
+  'Fashion',
+  'Film',
+  'Finance',
+  'Fitness',
+  'Food',
+  'Gaming',
+  'Health',
+  'Home Decor',
+  'Humor',
+  'Lifestyle',
+  'Makeup',
+  'Marketing',
+  'Mom',
+  'Music',
+  'Outdoor',
+  'Parenting',
+  'Pet',
+  'Photography',
+  'Political',
+  'Relationships',
+  'Self-help',
+  'Sewing',
+  'Sports',
+  'Tech',
+  'Travel',
+  'Wedding'
+];
+
+const seed = () =>
+  Promise.all(keywordList.map(keyword => Keyword.create({ name: keyword })));
+
+module.exports = seed;

--- a/backend/data/sync.js
+++ b/backend/data/sync.js
@@ -1,6 +1,12 @@
 const connection = require('./connection');
+const seed = require('./seed');
+
 const sync = async (force = false) => {
   await connection.sync({ force });
+
+  if (force) {
+    await seed();
+  }
 };
 
 module.exports = sync;


### PR DESCRIPTION
This PR seeds the database with a list of keywords to be used when onboarding a Creator.

A couple of things to note:
1. I kept `seed.js` as simple as possible because right now we're only seeding 1 table.
2. I had to require the `models` folder directly (instead of models from `data`) in `seed.js`. This is to avoid circular dependencies.